### PR TITLE
Handle failed airbrake notifications

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const addReqData = (req, err) =>
 const handle = curryN(3, (airbrake, req, err) => {
   airbrake.notify(addReqData(req, err), when(is(Error), notifyErr => {
     notifyErr.data = { err }
-    airbrake.notify(addReqData(notifyErr, req), when(is(Error), console.error))
+    airbrake.notify(addReqData(req, notifyErr), when(is(Error), console.error))
   }))
 
   return Promise.reject(err)

--- a/index.js
+++ b/index.js
@@ -1,14 +1,27 @@
-const { curryN } = require('crocks')
+const { curryN }         = require('crocks')
+const { flip, is, when } = require('ramda')
+
+const addReqData = (err, req) =>
+  when(is(Error), flip(Object.assign)({
+    action     : req.pathname,
+    component  : 'paperplane',
+    httpMethod : req.method,
+    params     : req.params,
+    ua         : req.headers['user-agent'],
+    url        : req.protocol + '://' + req.headers.host + req.url
+  }))(err)
 
 const handle = curryN(3, (airbrake, req, err) => {
-  err.action     = req.pathname
-  err.component  = 'paperplane'
-  err.httpMethod = req.method
-  err.params     = req.params
-  err.ua         = req.headers['user-agent']
-  err.url        = req.protocol + '://' + req.headers.host + req.url
-  airbrake.notify(err)
-  return Promise.reject(err)
+  const error = addReqData(err, req)
+
+  airbrake.notify(error, when(is(Error), e => {
+    const notifyErr = addReqData(e, req)
+    notifyErr.data = { err }
+
+    airbrake.notify(notifyErr, when(is(Error), console.error))
+  }))
+
+  return Promise.reject(error)
 })
 
 module.exports = curryN(2, (airbrake, app) => req =>

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const { curryN }         = require('crocks')
-const { flip, is, when } = require('ramda')
+const { curryN }   = require('crocks')
+const { is, when } = require('ramda')
 
 const addReqData = (req, err) =>
   Object.assign(err, {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "mocha --reporter dot"
   },
   "dependencies": {
-    "crocks": "^0.4.1"
+    "crocks": "^0.4.1",
+    "ramda": "^0.24.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -360,6 +360,10 @@ prop-factory@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/prop-factory/-/prop-factory-1.0.0.tgz#1a1f953b10be675b5524f2273e38dfba18151ae6"
 
+ramda@^0.24.1:
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
+
 readable-stream@1.1:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.13.tgz#f6eef764f514c89e2b9e23146a75ba106756d23e"


### PR DESCRIPTION
![](https://media.giphy.com/media/7VHV66bRjGRSo/giphy-downsized.gif)

Airbrake's notify method will exit the process by default if there is an unhandled error trying to report to Airbrake.

After talking over it with Scott, we decided on first fail to send the Airbrake letting you know it failed which will also include info about the original error.  If it fails again (in the case we cannot connect to Airbrake), it will log the error to STD OUT and move on.

Paging Mr. Herman @flintinatux 